### PR TITLE
fix: put hardcoded branch name in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
petite erreur sur la config du trigger de la ci. il faut mettre en dur le nom de la branche.